### PR TITLE
copy the state array instead of the reference

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,13 +17,13 @@ class App extends Component {
   }
   
   handleAllChecked = (event) => {
-    let fruites = this.state.fruites
+    let fruites = [...this.state.fruites]
     fruites.forEach(fruite => fruite.isChecked = event.target.checked) 
     this.setState({fruites: fruites})
   }
 
   handleCheckChieldElement = (event) => {
-    let fruites = this.state.fruites
+    let fruites = [...this.state.fruites]
     fruites.forEach(fruite => {
        if (fruite.value === event.target.value)
           fruite.isChecked =  event.target.checked


### PR DESCRIPTION
Since arrays are mutable, it is better the copy just the value of the array instead of its reference.